### PR TITLE
echo port number when launching server

### DIFF
--- a/bin/latexmls
+++ b/bin/latexmls
@@ -45,6 +45,8 @@ $g_opts->read(\@ARGV);
 
 # Set up the server
 my $server = setup_server($g_opts->get('port'));
+my $server_port = $server->sockport();
+print "LaTeXML server listening on $server_port\n";
 #**********************************************************************
 # Daemonize
 daemonize();


### PR DESCRIPTION
It can be useful to know which port the server was launched on in the event that no specific port number was given as a command line option
